### PR TITLE
Properly tag hermes docker images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# https://docs.docker.com/compose/environment-variables/
+
+# interpolate in docker-compose.yml
+# default to `master` if unset
+HERMES_CHECKOUT_TAG=v0.9.0
+
+# will raise error if unset
+HERMES_BUILD_TAG=0.9.0

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+.env
+
 ibc-relay-mnemonic
 keys/
 task/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CHAIN_AG=agoricdev-8
 CHAIN_COSMOS=cosmoshub-testnet
 IMAGE_AGORIC=agoric/agoric-sdk:agoricdev-8
 
-HERMES=docker run --rm -vhermes-home:/home/hermes:z -v$$PWD:/config hermes:0.9.0 -c /config/hermes.config
+HERMES=docker run --rm -vhermes-home:/home/hermes:z -v$$PWD:/config hermes -c /config/hermes.config
 
 # ISSUE: use matching key names in hermes.config for consistency
 ADDR_AG_KEY=keys/agdevkey
@@ -22,7 +22,7 @@ task/restore-keys: $(KEYFILE) task/hermes-image task/hermes-volume hermes.config
 	mkdir -p task && touch $@
 
 start: task/create-channel
-	docker-compose up -d
+	docker-compose up -d hermes-latest
 
 task/create-channel: hermes.config task/hermes-image task/hermes-volume \
 		task/restore-keys task/tap-cosmos-faucet task/tap-agoric-faucet

--- a/README-IBC.md
+++ b/README-IBC.md
@@ -5,19 +5,22 @@ I got my relayer to relay an IBC payment from the cosmos testnet to our devnet!
 
 ## Starting a hermes relayer between cosmos and agoric testnets
 
-_Grab the Makefile etc. by, for example, cloning this gist. Then:_
-
- 1. `make task/restore-keys` to:
-    - build a docker image for the [Hermes IBC Relayer CLI](https://github.com/informalsystems/ibc-rs/tree/master/relayer-cli) (v0.9.0)
+1. Setup `.env` file which defines the [Environment Variables for docker-compose.yml](https://docs.docker.com/compose/environment-variables/).
+    - `cp .env.example .env`
+    - Update `.env` file to suit your requirements
+1. `make task/restore-keys` to:
+    - build a docker image for the [Hermes IBC Relayer CLI](https://github.com/informalsystems/ibc-rs/tree/master/relayer-cli) with 2 tags:
+        - value of `HERMES_BUILD_TAG`
+        - `latest`
     - create a docker volume for the state
     - generate a mnemonic; import ("recover") secrets for accounts on both chains
- 2. **Update `ADDR_AG`, `ADDR_COSMOS` in `Makefile`** with the addresses from step 1.
- 3. `make task/tap-agoric-faucet`; follow instructions to tap the faucet; then `touch task/tap-agoric-faucet`
- 3. `make task/create-channel` to:
+    - export these accounts into `keys/` directory
+2. `make task/tap-agoric-faucet`; follow instructions to tap the faucet; then `touch task/tap-agoric-faucet`
+3. `make task/create-channel` to:
     - tap cosmos faucet
     - create an IBC channel
- 4. Take note of the channel ids (details below)
- 5. `make start` or `docker-compose up -d` to start the relayer.
+4. Take note of the channel ids (details below)
+5. `make start` or `docker-compose up -d hermes-latest` to start the relayer.
 
 Creating the IBC channel results in something like this that includes the channel ids:
 
@@ -78,7 +81,7 @@ Success: Channel {
 }
 ```
 
-## Provision user account on agorictest-6
+## Provision user account on agorictest-8
 
 Normally [Setting up an Agoric Dapp Client with docker compose](https://github.com/Agoric/agoric-sdk/wiki/Setting-up-an-Agoric-Dapp-Client-with-docker-compose) would suffice, but:
 
@@ -177,4 +180,3 @@ await result...
 most clues are from
  - [agoric-sdk pegasus/demo.md](https://github.com/Agoric/agoric-sdk/blob/master/packages/pegasus/demo.md)
  - [Agoric ↔ Pooltoy IBC Testnet [WIP]](https://hackmd.io/YYf5lsJXSSuatstpRDSs8g?view)
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,27 @@
 version: "3.7"
+
+x-hermes: &hermes-service-definition
+  build:
+    context: .
+    dockerfile: hermes.Dockerfile
+    args:
+      TAG: "${HERMES_CHECKOUT_TAG:-master}"
+  volumes:
+    - "hermes-home:/home/hermes"
+    - ".:/config:ro"
+  command:
+    - -c
+    - /config/hermes.config
+    - start
+
 services:
-  hermes:
-    build:
-      context: .
-      dockerfile: hermes.Dockerfile
-      args:
-        TAG: v0.9.0
-    image: hermes:0.9.0
-    volumes:
-      - "hermes-home:/home/hermes"
-      - ".:/config:ro"
-    command:
-      - -c
-      - /config/hermes.config
-      - start
+  hermes-tagged:
+    << : *hermes-service-definition
+    image: hermes:${HERMES_BUILD_TAG:?err}
+  hermes-latest:
+    << : *hermes-service-definition
+    image: hermes:latest
+
 volumes:
   hermes-home:
     external: true


### PR DESCRIPTION
* Use `.env` to parameterize hermes checkout & build tag
* Use [docker-compose extension-fields](https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields) to build a hermes images with 2 tag (`latest` & value defined in `.env`)
* Use `docker-compose up -d hermes-latest` to start only one hermes service